### PR TITLE
DO-3352 - remove AWS ID and SECRET ACCESS KEY from env variables in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM alpine:3.8
 
 # Default evironment variables.
-ENV AWS_DEFAULT_REGION us-east-1
-ENV AWS_ACCESS_KEY_ID defaultawsaccesskeyid
-ENV AWS_SECRET_ACCESS_KEY defaultawssecretaccesskey
 
 RUN apk add -q --update \
     && apk add -q \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 1.17
+
+Since we use this image in EKS and either the env variables are declared in the helm chart or we assume an IAM role, we don't want to set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the docker image to avoid conflicts with the service account annotation in order to assume an IAM role.
+
 # Docker AWS CLI Image (Docker Hub: vungle/awscli)
 
 Example:


### PR DESCRIPTION
In relation with https://github.com/Vungle/docker-geoipupdate/pull/2/files for the pod assuming role feature, we need to remove the declaration of AWS access keys within the docker image.

